### PR TITLE
Fix to build with GNURadio 3.7.5 on Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 #
 
 VERSION=2013102901
-CXXFLAGS=-DVERSION="\"gr-scan $(VERSION)\""  -Wall -lgnuradio-filter -lgnuradio-fft -lgnuradio-runtime -lgnuradio-osmosdr -lboost_system -O2 -s -Wno-unused-function
+CXXFLAGS=-DVERSION="\"gr-scan $(VERSION)\""  -Wall -lgnuradio-filter -lgnuradio-blocks -lgnuradio-pmt -lgnuradio-fft -lgnuradio-runtime -lgnuradio-osmosdr -lboost_system -O2 -s -Wno-unused-function
 
 gr-scan: *.cpp *.hpp Makefile
 	g++ $(CXXFLAGS) -o gr-scan main.cpp


### PR DESCRIPTION
Linking failed due to some missing libraries on the command.
